### PR TITLE
Remove warning message from about

### DIFF
--- a/src/docs/about.md
+++ b/src/docs/about.md
@@ -1,7 +1,3 @@
 # UK Cross-Government Metadata Exchange Model
 
-!!! warning
-    This is a working draft and has not yet been approved for release.
-
-
 A metadata model for describing data assets for exchanging between UK government organisations.

--- a/src/model/uk_cross_government_metadata_exchange_model.yaml
+++ b/src/model/uk_cross_government_metadata_exchange_model.yaml
@@ -2,11 +2,7 @@
 id: https://w3id.org/co-cddo/ukgov-metadata-exchange-model/
 name: uk-cross-government-metadata-exchange-model
 title: UK Cross-Government Metadata Exchange Model
-description: |
-  !!! warning 
-      This is a working draft and has not yet been approved for release.
-  
-  A metadata model for describing data assets for exchanging between UK government organisations.
+description: A metadata model for describing data assets for exchanging between UK government organisations.
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 see_also:
   - https://co-cddo.github.io/ukgov-metadata-exchange-model


### PR DESCRIPTION
This removed the warning text from the about and index pages.