### PR TITLE
Display examples and fix docker build

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build documentation.
         run: |
-          mkdir -p docs
+          make doc-setup
           touch docs/.nojekyll
           make gendoc
           make mkd-gh-deploy

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,5 +1,5 @@
 ---
-name: Auto-deployment of uk_cross_government_metadata_exchange_model Documentation
+name: Build and deploy docs site
 on:
   push:
     branches: 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,24 @@
 FROM python:3.10
+
 # Install make
 RUN apt update && apt install -y make
 
-# Copy configuration files
-COPY ./pyproject.toml ./mkdocs.yml /
-
-# Copy license file
-COPY ./LICENSE.md ./src/docs/ /docs/
-
-##TODO: Copy across examples and convert to JSON
-## Examples won't show until the above is done!
-# Copy source files for model
-COPY ./ /app
-WORKDIR /app
+# Install poetry
 RUN pip install poetry
+
+# Copy all files to app
+COPY ./ /app
+
+# set working directory
+WORKDIR /app
+
+# Setup environment
 RUN make install
 RUN make update
+
+# make docs
 RUN make doc-setup
+
+# serve docs
 EXPOSE 8080
 CMD make serve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
 FROM python:3.10
+# Install make
+RUN apt update && apt install -y make
+
 # Copy configuration files
 COPY ./pyproject.toml ./mkdocs.yml /
+
 # Copy license file
 COPY ./LICENSE.md ./src/docs/ /docs/
+
 ##TODO: Copy across examples and convert to JSON
 ## Examples won't show until the above is done!
 # Copy source files for model
-COPY ./src/ /src/
+COPY ./ /app
+WORKDIR /app
 RUN pip install poetry
-RUN poetry install
-RUN poetry run gen-doc -d /docs --template-directory src/docs/templates src/model/uk_cross_government_metadata_exchange_model.yaml
+RUN make install
+RUN make update
+RUN make doc-setup
 EXPOSE 8080
-CMD poetry run mkdocs serve
+CMD make serve

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo "  clean        remove all temporary files"
 	@echo "  gen-project  generate model constraints in different representations"
 	@echo "  test         run all the tests"
+	@echo "  doc-setup    create folders required for documentation site and copy across content"
 	@echo "  serve        run the documentation locally; need to use ctrl-c to close the documentation server down"
 	@echo "  docker-serve build and run the documentation in a Docker container"
 	@echo "  all          run clean, gen-project, test, and serve"
@@ -97,7 +98,7 @@ Distribution*.yaml:
 			$${file} ; \
 	done
 
-gen-examples: $(DOCDIR) ContactPoint*.yaml DataService*.yaml Dataset*.yaml Distribution*.yaml
+gen-examples: doc-setup ContactPoint*.yaml DataService*.yaml Dataset*.yaml Distribution*.yaml
 
 # TODO: Extend tests to lint schema to ensure elements are correctly described, see https://linkml.io/linkml/schemas/linter.html
 
@@ -155,7 +156,7 @@ test-invalid: src/model/uk_cross_government_metadata_exchange_model.yaml
 # serve will be passed as an argument to mkdocs
 serve: mkd-serve
 
-$(DOCDIR):
+doc-setup:
 	mkdir -p $(DOCDIR)
 	mkdir -p $(EXAMPLEDIR)
 	cp src/data/*/valid/* $(EXAMPLEDIR)


### PR DESCRIPTION
This PR fixes the issue with the examples not displaying.

I also realised that the same approach could be used to ensure that the docker build is the same as the GitHub build.