### PR TITLE
Fix #46 heading only displays if there is content

### DIFF
--- a/src/docs/templates/slot.md.jinja2
+++ b/src/docs/templates/slot.md.jinja2
@@ -45,6 +45,7 @@ Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}
 Mixin: {{ element.mixin }}
 {% endif -%}
 
+{% if element.comments %}
 ## Usage Notes
 
 {% set comments = element.comments | join('') %}
@@ -61,6 +62,7 @@ Mixin: {{ element.mixin }}
 {{ line }}
 {% endif %}
 {% endfor %}
+{% endif %}
 
 {% if schemaview.slot_parents(element.name) or schemaview.slot_children(element.name, mixins=False) %}
 


### PR DESCRIPTION
The usage note heading was displayed even if there was no content under it. This PR adds a simple check to see if there is a value. If there is then the heading and its content is displayed otherwise neither is displayed.