### PR TITLE
Show full enum description

### DIFF
--- a/src/docs/templates/enum.md.jinja2
+++ b/src/docs/templates/enum.md.jinja2
@@ -19,7 +19,7 @@ URI: {{ gen.uri_link(element) }}
 | Value | Meaning | Description |
 | --- | --- | --- |
 {% for pv in element.permissible_values.values() -%}
-| {{pv.text}} | {{pv.meaning}} | {{pv.description|enshorten}} |
+| {{pv.text}} | {{pv.meaning}} | {{pv.description}} |
 {% endfor %}
 {% else %}
 _This is a dynamic enum_


### PR DESCRIPTION
On the enum page, show the full description text for the enumeration item.

Fix #43 