### PR TITLE
Improve presentation of a properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,8 @@ doc-setup:
 	mkdir -p $(EXAMPLEDIR)
 	cp src/data/*/valid/* $(EXAMPLEDIR)
 
-gendoc: gen-examples
+#gendoc: doc-setup
+gendoc: test
 	cp src/docs/*.md $(DOCDIR)
 	cp LICENSE.md $(DOCDIR)
 	$(RUN) gen-doc -d $(DOCDIR) \

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ mkd-%: gendoc
 # Needed as macOS does not support multiple entities with the same name but different cases
 docker-serve:
 	docker build -t model-docs .   
-	docker run -p 8080:8080 model-docs
+	docker run --name ukgov-metadata-docs -p 8080:8080 model-docs
 ###########################################################
 # CLEANUP
 ###########################################################

--- a/src/docs/templates/class.md.jinja2
+++ b/src/docs/templates/class.md.jinja2
@@ -40,31 +40,25 @@ URI: {{ gen.uri_link(element) }}
 {% endif %}
 
 ## Properties
-{% macro slot_table_header() -%}
+{% macro slots_table(heading, slots) -%}
+{% if slots | length > 0 %}
+### {{ heading }} Properties
 | Name | Range | Description | Cardinality |
 | ---  | --- | --- | --- |
-{%- endmacro %}
-
-{% macro slot_table(slot) -%}
+{% for slot in slots -%}
 | {{gen.link(slot)}} | {{ gen.link(slot.range) }}{% if slot.minimum_value is not none %}<br/>Minimum Value: {{ slot.minimum_value|int }}{% endif %}{% if slot.maximum_value is not none %}<br/>Maximum Value: {{ slot.maximum_value|int }}{% endif %}{% if slot.pattern %}<br/>Regex pattern: {{ '`' }}{{  slot.pattern }}{{ '`' }}{% endif %} | {{ slot.description|enshorten }} | {% if slot.multivalued %}Many{% else %}One{% endif %} |
+{% endfor %}
+{% endif %}
 {%- endmacro %}
 
-### Mandatory Properties
-{{ slot_table_header() }}
-{% for slot in schemaview.class_induced_slots(element.name) | rejectattr("required", "none") | sort(attribute='name') -%}
-{{ slot_table(slot) }}
-{% endfor %}
+{% set slots = schemaview.class_induced_slots(element.name) | rejectattr("required", "none") | sort(attribute='name') -%}
+{{ slots_table("Mandatory", slots) }}
 
-### Recommended Properties
-{{ slot_table_header() }}
-{% for slot in schemaview.class_induced_slots(element.name) | rejectattr("recommended", "none") | sort(attribute='name') -%}
-{{ slot_table(slot) }}
-{% endfor %}
-### Optional Properties
-{{ slot_table_header() }}
-{% for slot in schemaview.class_induced_slots(element.name) | rejectattr("required") | rejectattr("recommended") | sort(attribute='name') -%}
-{{ slot_table(slot) }}
-{% endfor %}
+{% set slots = schemaview.class_induced_slots(element.name) | rejectattr("recommended", "none") | sort(attribute='name') -%}
+{{ slots_table("Recommended", slots) }}
+
+{% set slots = schemaview.class_induced_slots(element.name) | rejectattr("required") | rejectattr("recommended") | sort(attribute='name') -%}
+{{ slots_table("Optional", slots) }}
 
 {% if schemaview.is_mixin(element.name) %}
 ## Mixin Usage

--- a/src/docs/templates/class.md.jinja2
+++ b/src/docs/templates/class.md.jinja2
@@ -40,19 +40,31 @@ URI: {{ gen.uri_link(element) }}
 {% endif %}
 
 ## Properties
-
-| Name | Cardinality and Range | Description | Inheritance |
+{% macro slot_table_header() -%}
+| Name | Range | Description | Cardinality |
 | ---  | --- | --- | --- |
-{% if gen.get_direct_slots(element)|length > 0 %}
-{%- for slot in gen.get_direct_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | direct |
-{% endfor -%}
-{% endif -%}
-{% if gen.get_indirect_slots(element)|length > 0 %}
-{%- for slot in gen.get_indirect_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
-{% endfor -%}
-{% endif %}
+{%- endmacro %}
+
+{% macro slot_table(slot) -%}
+| {{gen.link(slot)}} | {{ gen.link(slot.range) }}{% if slot.minimum_value is not none %}<br/>Minimum Value: {{ slot.minimum_value|int }}{% endif %}{% if slot.maximum_value is not none %}<br/>Maximum Value: {{ slot.maximum_value|int }}{% endif %}{% if slot.pattern %}<br/>Regex pattern: {{ '`' }}{{  slot.pattern }}{{ '`' }}{% endif %} | {{ slot.description|enshorten }} | {% if slot.multivalued %}Many{% else %}One{% endif %} |
+{%- endmacro %}
+
+### Mandatory Properties
+{{ slot_table_header() }}
+{% for slot in schemaview.class_induced_slots(element.name) | rejectattr("required", "none") | sort(attribute='name') -%}
+{{ slot_table(slot) }}
+{% endfor %}
+
+### Recommended Properties
+{{ slot_table_header() }}
+{% for slot in schemaview.class_induced_slots(element.name) | rejectattr("recommended", "none") | sort(attribute='name') -%}
+{{ slot_table(slot) }}
+{% endfor %}
+### Optional Properties
+{{ slot_table_header() }}
+{% for slot in schemaview.class_induced_slots(element.name) | rejectattr("required") | rejectattr("recommended") | sort(attribute='name') -%}
+{{ slot_table(slot) }}
+{% endfor %}
 
 {% if schemaview.is_mixin(element.name) %}
 ## Mixin Usage

--- a/src/docs/templates/class.md.jinja2
+++ b/src/docs/templates/class.md.jinja2
@@ -51,10 +51,10 @@ URI: {{ gen.uri_link(element) }}
 {% endif %}
 {%- endmacro %}
 
-{% set slots = schemaview.class_induced_slots(element.name) | rejectattr("required", "none") | sort(attribute='name') -%}
+{% set slots = schemaview.class_induced_slots(element.name) | rejectattr("required", "none") | rejectattr("required", "false") | sort(attribute='name') -%}
 {{ slots_table("Mandatory", slots) }}
 
-{% set slots = schemaview.class_induced_slots(element.name) | rejectattr("recommended", "none") | sort(attribute='name') -%}
+{% set slots = schemaview.class_induced_slots(element.name) | rejectattr("recommended", "none") | rejectattr("recommended", "false") | sort(attribute='name') -%}
 {{ slots_table("Recommended", slots) }}
 
 {% set slots = schemaview.class_induced_slots(element.name) | rejectattr("required") | rejectattr("recommended") | sort(attribute='name') -%}

--- a/src/docs/templates/slot.md.jinja2
+++ b/src/docs/templates/slot.md.jinja2
@@ -15,31 +15,13 @@
 {% endfor %}
 {% endif %}
 
-URI: {{ gen.uri_link(element) }}
+## Obligation and Cardinality
 
-Range: {{gen.link(element.range)}}
+The obligation or cardinality can be overridden when used by classes. Check the [Applicable Classes](#applicable-classes) section below for details.
 
-{% if element.multivalued %}
-Multivalued: {{ element.multivalued }}
-{% endif -%}
-
-{% if element.required %}
-Required: {{ element.required }}
-{% elif element.recommended %}
-Recommended: {{ element.recommended }}
-{% endif -%}
-
-{% if element.minimum_value is not none %}
-Minimum Value: {{ element.minimum_value|int }}
-{% endif -%}
-
-{% if element.maximum_value is not none %}
-Maximum Value: {{ element.maximum_value|int }}
-{% endif -%}
-
-{% if element.pattern %}
-Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}
-{% endif -%}
+| URL                         | Range                       | Obligation  | Cardinality |
+|-----------------------------|-----------------------------|-------------|-------------|
+| {{ gen.uri_link(element) }} | {{gen.link(element.range)}} {% if element.minimum_value is not none %}<br/>Minimum Value: {{ element.minimum_value|int }}{% endif %}{% if element.maximum_value is not none %}<br/>Maximum Value: {{ element.maximum_value|int }}{% endif %}{% if element.pattern %}<br/>Regex pattern: {{ '`' }}{{  element.pattern }}{{ '`' }}{% endif %} | {% if element.required %}Mandatory{% elif element.recommended %}Recommended{% else %}Optional{% endif %} | {% if element.multivalued %}Many{% else %}One{% endif %} |
 
 {% if schemaview.is_mixin(element.name) %}
 Mixin: {{ element.mixin }}

--- a/src/model/uk_cross_government_metadata_exchange_model.yaml
+++ b/src/model/uk_cross_government_metadata_exchange_model.yaml
@@ -72,13 +72,6 @@ classes:
       - type
       - theme
       - version
-    slot_usage:
-      accessRights:
-        required: true
-      description:
-        required: true
-      modified:
-        required: true
 
   DataService:
     is_a: DataResource
@@ -119,6 +112,10 @@ classes:
       - title
       - type
     slot_usage:
+      accessRights: 
+        required: false
+      description:
+        required: false
       modified:
         recommended: true
 
@@ -145,6 +142,7 @@ slots:
   accessRights:
     slot_uri: dct:accessRights
     description: A rights statement that concerns how the distribution is accessed.
+    required: true
     range: AccessRightsValues
   address:
     slot_uri: vcard:hasAddress
@@ -291,6 +289,7 @@ slots:
     description: |
       A concise narrative of the content of an information resource.
       A free-text account of the distribution.
+    required: true
     range: string
     comments: |
       purpose:
@@ -450,6 +449,7 @@ Note that there could be a security risk in sharing the endpoint URL for interna
   modified:
     slot_uri: dct:modified
     description: The date, or date and time, on which the content of an information resource is changed.
+    required: true
     range: date
     comments: |
       purpose:
@@ -563,11 +563,19 @@ Note that there could be a security risk in sharing the endpoint URL for interna
   summary:
     slot_uri: rdfs:comment
     description: |
-      "A short textual summary of the resource with a maximum length of 250 characters. 
-
-      Usage note: The intended use of this text is in a page containing multiple search results. If omitted, the first part of the description text will be used. This may be up to a certain character count or the detection of a paragraph break."
+      A short textual summary of the resource with a maximum length of 250 characters. 
     recommended: true
     range: string
+    pattern: ^.{1,250}$
+    comments: |
+      purpose:
+        The intended use of this text is in a page containing multiple search results where a short one sentence or so summary is needed. 
+        
+        If omitted, the first part of the description text will be used. This may be up to a certain character count or the detection of a paragraph break, it is up to the application to decide.
+      distinctFrom:
+        - [`description`](/ukgov-metadata-exchange-model/description): to capture a full overview of the data asset
+      guidance:
+        The `summary` will be used where a short text overview of the data asset is required, e.g. in a page of search results. It should provide an idea of what the data asset provides but not give full details. Conciseness is key. 
   telephone:
     slot_uri: vcard:hasTelephone
     description: Telephone number for the contact team

--- a/src/model/uk_cross_government_metadata_exchange_model.yaml
+++ b/src/model/uk_cross_government_metadata_exchange_model.yaml
@@ -117,6 +117,7 @@ classes:
       description:
         required: false
       modified:
+        required: false
         recommended: true
 
   Organisation:


### PR DESCRIPTION
This PR changes the way that properties are presented both on the class pages and on the property specific pages and is a fix for #51. The new presentation provides more interpretation of the attributes of the properties to make them accessible to a wider set of users.

On a class page, the properties are now grouped by their obligation level (Mandatory, Recommended, and Optional) and ordered alphabetically within them. Each table of properties includes a hyperlink to the property, its expected range including any constraints such a minimum values, a summary of its description, and its cardinality (One or Many). An obligation level is only displayed if there are properties of that level. (See screenshots below).

On a property page, the attributes of the property are now displayed in their own section in a table using the primary definition of the property, i.e. if a property has different obligations for different classes then the primary definition is displayed on the property page (see modified for an example of this). The table includes the URL of the property, its range, obligation level, and cardinality.

## Screenshots

### Class pages
![Screenshot 2023-10-27 at 12 00 36](https://github.com/co-cddo/ukgov-metadata-exchange-model/assets/1141265/501f0d26-10bd-4f1a-9ce2-2afbb0baaed7)
![Screenshot 2023-10-27 at 12 00 45](https://github.com/co-cddo/ukgov-metadata-exchange-model/assets/1141265/ecea216b-28dc-4cb5-8e79-537b37bc1d92)


### Property pages
Example with cardinality of one and mandatory:
![Screenshot 2023-10-26 at 10 47 58](https://github.com/co-cddo/ukgov-metadata-exchange-model/assets/1141265/77ea8e2e-a008-468b-8850-6e1cec55d7a6)

Example with cardinality of many:
![Screenshot 2023-10-26 at 10 48 59](https://github.com/co-cddo/ukgov-metadata-exchange-model/assets/1141265/b231e13c-4b94-4f7a-a6a1-897b42bff0c2)

Example with a regular expression pattern:
![Screenshot 2023-10-26 at 10 49 33](https://github.com/co-cddo/ukgov-metadata-exchange-model/assets/1141265/a0e1c7f8-e7f5-4b85-8824-99b1623e916a)

Example with a minimum value (we don't have any maximum values set but it would work the same):
![Screenshot 2023-10-26 at 10 50 19](https://github.com/co-cddo/ukgov-metadata-exchange-model/assets/1141265/d49063c4-92db-4e1f-bd44-59ab23158171)

Example with an obligation of optional:
![Screenshot 2023-10-26 at 10 51 28](https://github.com/co-cddo/ukgov-metadata-exchange-model/assets/1141265/1b9d5873-f9a0-402e-9f2c-61493472bdff)



