### PR TITLE
Fix Enum URI links

### DIFF
--- a/src/docs/templates/enum.md.jinja2
+++ b/src/docs/templates/enum.md.jinja2
@@ -11,7 +11,7 @@ _{{ element_description_line }}_
 {% endfor %}
 {% endif %}
 
-URI: {{ gen.uri_link(element) }}
+URI: {{ gen.link(element) }}
 
 {% if element.permissible_values -%}
 ## Permissible Values


### PR DESCRIPTION
This fixes #61 where the URI link on an Enum page resulted in a 404 error.