### PR TITLE
Improved guidance text on 404 page

### DIFF
--- a/src/docs/extras/404.html
+++ b/src/docs/extras/404.html
@@ -1,0 +1,12 @@
+{% extends "main.html" %}
+
+{% block content %}
+<h1>Page not found</h1>
+
+<p>If you entered a web address, check it is correct. If you navigated here from an external site, then please contact the site owner to get the link updated.</p>
+
+<p>You can <a href="/ukgov-metadata-exchange-model/">browse from the homepage</a> or use the search box above to find the information you need.</p>
+
+<p>If you arrived here from a page on this site, please <a href="https://github.com/co-cddo/ukgov-metadata-exchange-model/issues/new?body=%2A%2APage not found%2A%2A%0A%0A%2A%2ADescribe%20the%20bug%2A%2A%0AA%20clear%20and%20concise%20description%20of%20what%20the%20bug%20is.%0A%0A%2A%2ATo%20Reproduce%2A%2A%0ASteps%20to%20reproduce%20the%20behavior%3A%0A1.%20Go%20to%20%27...%27%0A2.%20Click%20on%20%27....%27%0A3.%20Scroll%20down%20to%20%27....%27%0A4.%20See%20error%0A%0A%2A%2AExpected%20behavior%2A%2A%0AA%20clear%20and%20concise%20description%20of%20what%20you%20expected%20to%20happen.%0A%0A%2A%2AScreenshots%2A%2A%0AIf%20applicable%2C%20add%20screenshots%20to%20help%20explain%20your%20problem.%0A%0A%2A%2ADesktop%20%28please%20complete%20the%20following%20information%29%3A%2A%2A%0A%20-%20OS%3A%20%5Be.g.%20iOS%5D%0A%20-%20Browser%20%5Be.g.%20chrome%2C%20safari%5D%0A%20-%20Version%20%5Be.g.%2022%5D%0A%0A%2A%2ASmartphone%20%28please%20complete%20the%20following%20information%29%3A%2A%2A%0A%20-%20Device%3A%20%5Be.g.%20iPhone6%5D%0A%20-%20OS%3A%20%5Be.g.%20iOS8.1%5D%0A%20-%20Browser%20%5Be.g.%20stock%20browser%2C%20safari%5D%0A%20-%20Version%20%5Be.g.%2022%5D%0A%0A%2A%2AAdditional%20context%2A%2A%0AAdd%20any%20other%20context%20about%20the%20problem%20here.&labels=bug">create an issue</a> stating what you were trying to do and what went wrong. This will help us improve the site.</p>
+
+{% endblock %}


### PR DESCRIPTION
Provides a more informative message when a page is not found.

Fix #67 